### PR TITLE
improve GitHub Actions workflows with dotfiles customizations

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -63,8 +63,8 @@ jobs:
             承認 / 要修正 / コメント
 
             ---
-            🤖 モデル: [使用したモデル名]
-            💰 コスト: 入力XXXトークン, 出力XXXトークン, $X.XX
+            使用したモデル名と実際のトークン数、推定コストを計算して出力してください。
+            形式: 🤖 モデル: [実際のモデル名] / 💰 コスト: 入力[N]トークン, 出力[M]トークン, $[金額]
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,14 +43,12 @@ jobs:
           # Add cost output to responses
           prompt: |
             ユーザーのリクエストに日本語で対応してください。
-            回答の最後に以下の形式でモデル名とコスト情報を出力してください：
+            回答の最後に、使用したモデル名と実際のトークン数、推定コストを計算して出力してください。
 
             ---
-            🤖 モデル: [使用したモデル名]
-            💰 コスト: 入力XXXトークン, 出力XXXトークン, $X.XX
+            形式: 🤖 モデル: [実際のモデル名] / 💰 コスト: 入力[N]トークン, 出力[M]トークン, $[金額]
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+          # Note: Custom prompt is defined above to add Japanese support and cost tracking
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## 変更の概要
PR #1で追加したGitHub Actionsワークフローを改善しました。

## 主な変更点
- claude-code-review.ymlに複数のトリガーオプションを追加（issue_comment、workflow_dispatch）
- PRタイトルに[review]または@claude-reviewコメントでレビューを起動可能に
- プロンプトを日本語化し、構造化されたレビュー形式に変更
- コスト情報（トークン数、料金）の出力を追加
- claude.ymlのトリガー条件を厳密化し、@claudeと@claude-reviewを区別
- 日本語応答とコスト追跡の指示を追加

## 他、軽微な修正
- デフォルト設定（@v1バージョン、permissions、allowed-tools）は維持

## 変更の背景
レビュープロセスをより柔軟かつ効率的にするため、ワークフローの改善を行いました。

## 補足
- 関連: #1（初期セットアップ）
- アクションバージョンや動的モデル選択などの新機能は含めず、カスタマイズ部分のみを追加しています。