### PR TITLE
fix: enable track_progress for PR comment posting

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,6 +42,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
 
           # Direct prompt for automated review (no @claude mention needed)
           prompt: |
@@ -65,8 +66,6 @@ jobs:
             ---
             使用したモデル名と実際のトークン数、推定コストを計算して出力してください。
             形式: 🤖 モデル: [実際のモデル名] / 💰 コスト: 入力[N]トークン, 出力[M]トークン, $[金額]
-
-            レビューが完了したら、Bashツールで`gh pr comment`を使用してPRにコメントを投稿してください。
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options


### PR DESCRIPTION
## 変更の概要
PR #2 の続きとして、claude-code-review.ymlに`track_progress: true`を追加しました。

## 主な変更点
- claude-code-review.ymlに`track_progress: true`オプションを追加
- プロンプトから明示的な`gh pr comment`指示を削除

## 変更の背景
betaからv1への移行により、PRへのコメント投稿の挙動が変更されました。v1では`track_progress: true`を明示的に指定する必要があります（https://github.com/anthropics/claude-code-action  #567で報告されている既知の問題）。

## 補足
- 関連: #2（GitHub Actionsワークフローの改善）
- betaでは自動的にPRコメントが投稿されていましたが、v1では`track_progress: true`が必要です