### PR TITLE
[review] fix: Correct GitHub Actions heredoc syntax for multiline output

### DIFF
--- a/.github/workflows/notifier.yml
+++ b/.github/workflows/notifier.yml
@@ -32,11 +32,9 @@ jobs:
             echo "📦 Found new releases:"
             cat releases.json
             # Save releases data to output for Claude translation
-            {
-              echo "releases_data<<EOF"
-              cat releases.json
-              echo "EOF"
-            } >> $GITHUB_OUTPUT
+            echo "releases_data<<EOF" >> $GITHUB_OUTPUT
+            cat releases.json >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
           else
             echo "has_releases=false" >> $GITHUB_OUTPUT
             echo "ℹ️  No new releases found"


### PR DESCRIPTION
## 変更の概要

GitHub Actionsワークフローの初回実行時に発生したヒアドキュメント構文エラーを修正しました。

## 主な変更点

- .github/workflows/notifier.yml: Check for new releasesステップのヒアドキュメント構文を修正
  - ブレースグルーピングから個別リダイレクトに変更
  - GitHub Actions推奨パターンに準拠

## 変更の背景

ワークフローの初回実行で以下のエラーが発生しました。

```
Invalid value. Matching delimiter not found 'EOF'
Unable to process file command 'output' successfully.
```

原因は、multiline outputのヒアドキュメントでブレースグルーピングを使用していたことでした。

修正前:
```yaml
{
  echo "releases_data<<EOF"
  cat releases.json
  echo "EOF"
} >> $GITHUB_OUTPUT
```

修正後:
```yaml
echo "releases_data<<EOF" >> $GITHUB_OUTPUT
cat releases.json >> $GITHUB_OUTPUT
echo "EOF" >> $GITHUB_OUTPUT
```

## 補足

GitHub Actions公式ドキュメントの推奨パターンに従った修正です。

参考: [Workflow commands for GitHub Actions - Multiline strings](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings)