### PR TITLE
[review] fix: Add trailing newline to JSON output files

### DIFF
--- a/devtools_release_notifier/notifier.py
+++ b/devtools_release_notifier/notifier.py
@@ -123,6 +123,7 @@ class UnifiedReleaseNotifier:
         try:
             with open(cache_path, "w") as f:
                 json.dump(cached.model_dump(), f, indent=2)
+                f.write("\n")
         except OSError as e:
             print(f"⚠️  Failed to write cache for {tool_name}: {e}")
 
@@ -222,6 +223,7 @@ class UnifiedReleaseNotifier:
                 # Convert Pydantic models to dicts
                 releases_data = [r.model_dump() for r in self.new_releases]
                 json.dump(releases_data, f, indent=2)
+                f.write("\n")
             print(f"\n✓ Wrote {len(self.new_releases)} new releases to {output_file}")
 
         print("\n✅ Completed")


### PR DESCRIPTION
## 変更の概要

JSON出力ファイルの末尾に改行を追加し、GitHub Actionsのheredoc構文エラーを根本的に解決しました。

## 主な変更点

- devtools_release_notifier/notifier.py: `json.dump()`の後に`f.write("\n")`を追加
  - キャッシュファイル保存時（126行目）
  - releases.json出力時（226行目）

## 変更の背景

GitHub Actionsワークフローで「Invalid value. Matching delimiter not found 'EOF'」エラーが発生していました。

原因は、Pythonの`json.dump()`が末尾に改行を出力しないため、heredoc構文のdelimiter（`EOF`）が前の行と結合してしまうことでした。

修正により、JSONファイルが改行で終わるようになり、GitHub Actionsのheredoc構文が正しく動作します。

## 補足

POSIXテキストファイル規約にも準拠し、すべてのテキストファイルは改行で終わるべきという標準に従っています。