### PR TITLE
[review] fix: handle array format execution file from claude-code-action

### DIFF
--- a/.github/scripts/extract_claude_response.py
+++ b/.github/scripts/extract_claude_response.py
@@ -74,7 +74,7 @@ def extract_claude_response(execution_file_path: str) -> str:
         raise ValueError(f"Failed to parse execution file as JSON: {e}") from e
 
     # Try to extract response from various possible structures
-    # Attempt 1: If data is a list (array), look for type="result" or type="assistant"
+    # Array format handling: If data is a list (array), look for type="result" or type="assistant"
     if isinstance(data, list):
         # Try from last to first
         for item in reversed(data):
@@ -109,7 +109,7 @@ def extract_claude_response(execution_file_path: str) -> str:
                         if json_response:
                             return json_response
 
-    # Attempt 2: Look for 'response' or 'output' field (dict format)
+    # Dict format - direct fields: Look for 'response' or 'output' field
     if isinstance(data, dict):
         for key in ["response", "output", "result", "content"]:
             if key in data:
@@ -119,7 +119,7 @@ def extract_claude_response(execution_file_path: str) -> str:
                     if json_response:
                         return json_response
 
-        # Attempt 3: Look for messages array
+        # Dict format - messages array: Look for messages array
         if "messages" in data and isinstance(data["messages"], list):
             # Get the last assistant message
             for msg in reversed(data["messages"]):
@@ -130,7 +130,7 @@ def extract_claude_response(execution_file_path: str) -> str:
                         if json_response:
                             return json_response
 
-        # Attempt 4: Look for conversation or history
+        # Dict format - conversation/history: Look for conversation or history
         for key in ["conversation", "history", "transcript"]:
             if key in data and isinstance(data[key], list):
                 # Get the last item


### PR DESCRIPTION
## 変更の概要

`extract_claude_response.py`が配列形式の実行ファイルに対応できるように修正しました。

## 主な変更点

- 配列形式の実行ファイル処理を追加（`type="result"`および`type="assistant"`をサポート）
- `type="result"`の場合、`result`フィールドからJSONを抽出
- `type="assistant"`の場合、`message.content`構造からJSONを抽出
- 辞書形式との後方互換性を維持

## 変更の背景

GitHub Actionsでのワークフロー実行時、`anthropics/claude-code-action@v1`が返す実行ファイルは配列形式でした。しかし、`extract_claude_response.py`は辞書形式を前提としていたため、JSON抽出に失敗していました。

デバッグ出力から実際の構造を確認し、配列形式に対応する処理を追加しました。

## 補足

実際の実行ファイル構造に基づいてテストファイルを作成し、ローカルでテスト済みです。