### PR TITLE
[review] Fix git push authentication error in workflow

### DIFF
--- a/.github/workflows/notifier.yml
+++ b/.github/workflows/notifier.yml
@@ -131,8 +131,8 @@ jobs:
             echo "ℹ️  No changes to commit"
           else
             git commit -m "chore: update release cache and logs [skip ci]"
-            gh repo set-default ${{ github.repository }}
             gh auth setup-git
+            gh repo set-default ${{ github.repository }}
             git push
             echo "✓ Cache and Markdown logs updated"
           fi


### PR DESCRIPTION
## 変更の概要

GitHub Actionsワークフローにおけるgit push認証エラーを修正しました。

## 主な変更点

- `GH_TOKEN` 環境変数を追加してgh CLIの認証を設定
- git pushの前に `gh auth setup-git` を実行
- `gh repo set-default` でリポジトリのデフォルト設定を追加

## 変更の背景

anthropics/claude-code-action@v1 の実行後、git pushで認証エラーが発生していました。

```
fatal: Authentication failed for 'https://github.com/rysk-tanaka/devtools-release-notifier.git/'
```

claude-code-actionが内部でgit操作を行う際に、actions/checkout@v4で設定された認証情報がクリアされる可能性があります。

gh CLIを使用してgit認証を再設定することで、この問題を解決しました。

## 補足

- ワークフロー実行ログ: https://github.com/rysk-tanaka/devtools-release-notifier/actions/runs/19403544197
- `continue-on-error: true` が設定されているため、ワークフロー自体は成功していますが、キャッシュとログのコミット・プッシュに失敗していました