### PR TITLE
[review] Fix automatic documentation deployment trigger

### DIFF
--- a/.github/workflows/notifier.yml
+++ b/.github/workflows/notifier.yml
@@ -119,6 +119,7 @@ jobs:
           exit $EXIT_CODE
 
       - name: Commit cache and Markdown logs
+        id: commit
         if: steps.check.outputs.has_releases == 'true'
         continue-on-error: true
         run: |
@@ -135,7 +136,8 @@ jobs:
           fi
 
       - name: Trigger documentation deployment
-        if: steps.check.outputs.has_releases == 'true'
+        if: steps.check.outputs.has_releases == 'true' && steps.commit.outcome == 'success'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## 変更の概要

github-actions[bot]によるコミット後に、ドキュメントデプロイワークフローが自動実行されるように修正しました。

## 主な変更点

- notifier.ymlの`permissions`に`actions: write`を追加
- キャッシュとMarkdownログのコミット後に、deploy-docs.ymlを明示的にトリガーするステップを追加

## 変更の背景

現在、github-actions[bot]がリリース情報を更新してコミットしても、deploy-docs.ymlワークフローが自動実行されない問題がありました。これはGitHub Actionsのデフォルト動作として、botによるコミットはCI/CDワークフローをトリガーしないためです（無限ループ防止）。

この修正により、新しいリリース情報が検出された際に、以下の流れで自動的にドキュメントサイトがデプロイされるようになります。

1. notifier.ymlが新しいリリースを検出
2. Claudeで翻訳してDiscordに通知
3. Markdownログを保存してコミット
4. deploy-docs.ymlを明示的にトリガー
5. ドキュメントサイトが自動デプロイ

## 補足

この修正により、PATの管理が不要になり、セキュリティリスクを低減しつつ、シンプルで明示的な実装となっています。